### PR TITLE
Do not change _matrix when zooming reached the max/min values

### DIFF
--- a/src/Avalonia.Controls.PanAndZoom/ZoomBorder.cs
+++ b/src/Avalonia.Controls.PanAndZoom/ZoomBorder.cs
@@ -421,6 +421,12 @@ public partial class ZoomBorder : Border
         {
             return;
         }
+
+        if((ZoomX >= MaxZoomX && ZoomY >= MaxZoomY && ratio > 1) || (ZoomX <= MinZoomX && ZoomY <= MinZoomY && ratio < 1))
+        {
+            return;
+        }
+        
         _updating = true;
 
         Log("[ZoomTo]");


### PR DESCRIPTION
Do not change _matrix when zooming reached the max/min values (#80)