### PR TITLE
Update MatrixHelperTests.cs

### DIFF
--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/MatrixHelperTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/MatrixHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 namespace Avalonia.Controls.PanAndZoom.UnitTests;
 
@@ -15,7 +15,7 @@ public class MatrixHelperTests
         Assert.Equal(20.0, target.M31);
         Assert.Equal(30.0, target.M32);
     }
- 
+
     [Fact]
     public void Scale_Returns_Matrix()
     {
@@ -26,5 +26,158 @@ public class MatrixHelperTests
         Assert.Equal(3.0, target.M22);
         Assert.Equal(0.0, target.M31);
         Assert.Equal(0.0, target.M32);
+    }
+
+    [Fact]
+    public void Transform_Point_Identity()
+    {
+        var inputPoint = new Point(0, 0);
+        var testMatrix = new Matrix();
+        var outputPoint = MatrixHelper.TransformPoint(testMatrix, inputPoint);
+
+        Assert.Equal(0, inputPoint.X);
+        Assert.Equal(0, inputPoint.Y);
+
+        Assert.Equal(0, outputPoint.X);
+        Assert.Equal(0, outputPoint.Y);
+    }
+
+    [Fact]
+    public void Transform_Point_Positive()
+    {
+        var inputPoint = new Point(2, 1);
+        var testMatrix = new Matrix(1.0, 0.0, 0.0, 2.0, 0.0, 0.0);
+        var outputPoint = MatrixHelper.TransformPoint(testMatrix, inputPoint);
+
+        Assert.Equal(2, inputPoint.X);
+        Assert.Equal(1, inputPoint.Y);
+
+        Assert.Equal(2, outputPoint.X);
+        Assert.Equal(2, outputPoint.Y);
+    }
+
+    [Fact]
+    public void ScaleAt_Same_Returns_Identity()
+    {
+        double scaleX = 1.0;
+        double scaleY = 1.0;
+        double centerX = 0.0;
+        double centerY = 0.0;
+        var outputMatrix = MatrixHelper.ScaleAt(scaleX, scaleY, centerX, centerY);
+        Assert.True(outputMatrix.IsIdentity);
+    }
+
+    [Fact]
+    public void ScaleAt_SameScale_PositiveCenter_Returns_Identity()
+    {
+        double scaleX = 1.0;
+        double scaleY = 1.0;
+        double centerX = 1.0;
+        double centerY = 2.0;
+        var outputMatrix = MatrixHelper.ScaleAt(scaleX, scaleY, centerX, centerY);
+        Assert.True(outputMatrix.IsIdentity);
+    }
+
+    [Fact]
+    public void ScaleAt_DoubleScale_PositiveCenter()
+    {
+        double scaleX = 2.0;
+        double scaleY = 2.0;
+        double centerX = 1.0;
+        double centerY = 2.0;
+        var outputMatrix = MatrixHelper.ScaleAt(scaleX, scaleY, centerX, centerY);
+
+        Assert.Equal(2.0, outputMatrix.M11);
+        Assert.Equal(0.0, outputMatrix.M12);
+        Assert.Equal(0.0, outputMatrix.M13);
+        Assert.Equal(0.0, outputMatrix.M21);
+        Assert.Equal(2.0, outputMatrix.M22);
+        Assert.Equal(0.0, outputMatrix.M23);
+        Assert.Equal(-1.0, outputMatrix.M31);
+        Assert.Equal(-2.0, outputMatrix.M32);
+        Assert.Equal(1.0, outputMatrix.M33);
+    }
+
+    [Fact]
+    public void ScaleAt_HalfScale_NegCenter()
+    {
+        double scaleX = 0.5;
+        double scaleY = 0.5;
+        double centerX = -1.0;
+        double centerY = -2.0;
+        var outputMatrix = MatrixHelper.ScaleAt(scaleX, scaleY, centerX, centerY);
+
+        Assert.Equal(0.5, outputMatrix.M11);
+        Assert.Equal(0.0, outputMatrix.M12);
+        Assert.Equal(0.0, outputMatrix.M13);
+        Assert.Equal(0.0, outputMatrix.M21);
+        Assert.Equal(0.5, outputMatrix.M22);
+        Assert.Equal(0.0, outputMatrix.M23);
+        Assert.Equal(-0.5, outputMatrix.M31);
+        Assert.Equal(-1.0, outputMatrix.M32);
+        Assert.Equal(1.0, outputMatrix.M33);
+    }
+
+    [Fact]
+    public void ScaleAndTranslate_Same_Returns_Identity()
+    {
+        double scaleX = 1.0;
+        double scaleY = 1.0;
+        double x = 0.0;
+        double y = 0.0;
+        var outputMatrix = MatrixHelper.ScaleAndTranslate(scaleX, scaleY, x, y);
+        Assert.True(outputMatrix.IsIdentity);
+    }
+
+    [Fact]
+    public void ScaleAndTranslate_DoubleScale_PositiveShift()
+    {
+        double scaleX = 2.0;
+        double scaleY = 2.0;
+        double x = 1.0;
+        double y = 2.0;
+        var outputMatrix = MatrixHelper.ScaleAndTranslate(scaleX, scaleY, x, y);
+
+        Assert.Equal(2.0, outputMatrix.M11);
+        Assert.Equal(0.0, outputMatrix.M12);
+        Assert.Equal(0.0, outputMatrix.M13);
+        Assert.Equal(0.0, outputMatrix.M21);
+        Assert.Equal(2.0, outputMatrix.M22);
+        Assert.Equal(0.0, outputMatrix.M23);
+        Assert.Equal(1.0, outputMatrix.M31);
+        Assert.Equal(2.0, outputMatrix.M32);
+        Assert.Equal(1.0, outputMatrix.M33);
+    }
+
+    [Fact]
+    public void ScaleAndTranslate_HalfScale_NegativeShift()
+    {
+        double scaleX = 0.5;
+        double scaleY = 0.5;
+        double x = -1.0;
+        double y = -2.0;
+        var outputMatrix = MatrixHelper.ScaleAndTranslate(scaleX, scaleY, x, y);
+
+        Assert.Equal(0.5, outputMatrix.M11);
+        Assert.Equal(0.0, outputMatrix.M12);
+        Assert.Equal(0.0, outputMatrix.M13);
+        Assert.Equal(0.0, outputMatrix.M21);
+        Assert.Equal(0.5, outputMatrix.M22);
+        Assert.Equal(0.0, outputMatrix.M23);
+        Assert.Equal(-1.0, outputMatrix.M31);
+        Assert.Equal(-2.0, outputMatrix.M32);
+        Assert.Equal(1.0, outputMatrix.M33);
+    }
+
+    [Fact]
+    public void ScaleAtPrepend_HalfScale_With_DoubleScale_Returns_Identity()
+    {
+        var halfScaleMatrix = MatrixHelper.Scale(0.5, 0.5);
+
+        double scaleX = 2.0;
+        double scaleY = 2.0;
+        var outputMatrix = MatrixHelper.ScaleAtPrepend(halfScaleMatrix, scaleX, scaleY, 0, 0);
+
+        Assert.True(outputMatrix.IsIdentity);
     }
 }


### PR DESCRIPTION
Created unit tests for TransformPoint, ScaleAt, ScaleAndTranslate, and ScaleAtPrepend
Linked to Issue (https://github.com/wieslawsoltes/PanAndZoom/issues/88)

Unit Tests Summary:
1.	Transform_Point_identity
Verifies Transform point works with an identity matrix

2.	Transform_Point_Positive
Verifies Transform point works with a positive valued matrix with a positive point (moves the matrix across 2D plane (ie 2D-->2D)
 
3.	ScaleAt_Same_Returns_Identity
Verifies scaling with a center point works on a base point (ideal case)

4.	ScaleAt_SameScale_PositiveCenter_Returns_Identity
Verifies scaling the Matrix with a positive point (1,2) works
 
5.	ScaleAt_DoubleScale_PositiveCenter()
Verifies the scaling matrix function works by doubling the Matrix size centered along the point (1,2)

6.	ScaleAt_HalfScale_NegCenter()
Verifies halving (scaling down) the matrix size works with a negative offset (shifts to the upper left) with the point (-1, -2). 
 
7.	ScaleAndTranslate_Same_Returns_Identity
Verifies a base case for a transposed Matrix (tests logic of multiple matrix transformations at once)

8.	ScaleAndTranslate_DoubleScale_PositiveShift
Since base case was verified in Unit Test 7, I then tested to verify that doubling and shifting the Matrix behaves correctly.
 
9.	ScaleAndTranslate_HalfScale_NegativeShift
Verifies halving and shifting the matrix with a negative x,y offset works

10.	ScaleAtPrepend_HalfScale_With_DoubleScale_Returns_Identity
Verifies doubling half will return the identity (normal size). Basically, if you start with a small (half size) window, and double the size, you zoom out to a normal window size. 
