### PR TITLE
Fix CalculateScrollable with positioned source

### DIFF
--- a/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
+++ b/src/PanAndZoom/ZoomBorder.ILogicalScrollable.cs
@@ -28,7 +28,7 @@ public partial class ZoomBorder : ILogicalScrollable
     /// <param name="offset">The current scroll offset.</param>
     public static void CalculateScrollable(Rect source, Size borderSize, Matrix matrix, out Size extent, out Size viewport, out Vector offset)
     {
-        var bounds = new Rect(0, 0, source.Width, source.Height);
+        var bounds = new Rect(source.Position, source.Size);
             
         viewport = borderSize;
 

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTests.cs
@@ -117,6 +117,18 @@ public class ZoomBorderTests
     }
 
     [Fact]
+    public void CalculateScrollable_Source_With_Negative_Position()
+    {
+        var borderSize = new Size(300, 300);
+        var bounds = new Rect(-50, -30, 200, 200);
+        var matrix = CreateMatrix();
+        ZoomBorder.CalculateScrollable(bounds, borderSize, matrix, out var extent, out var viewport, out var offset);
+        Assert.Equal(new Size(350, 330), extent);
+        Assert.Equal(new Size(300, 300), viewport);
+        Assert.Equal(new Vector(50, 30), offset);
+    }
+
+    [Fact]
     public void CalculateScrollable_OffsetX_Negative()
     {
         var borderSize = new Size(300, 300);


### PR DESCRIPTION
## Summary
- respect source position when computing scroll bounds
- add regression test for non-zero source position

## Testing
- `dotnet test PanAndZoom.sln`

------
https://chatgpt.com/codex/tasks/task_e_687cabe606048321b4f25bbddd320fec