### PR TITLE
Dispose bitmap sources on replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ To constrain pan offset use `MinOffsetX`, `MaxOffsetX`, `MinOffsetY` and `MaxOff
 
 To enable or disable constrains use `EnableConstrains` flag.
 
+### Dispose image sources
+
+When replacing images inside `ZoomBorder`, dispose the previous `Image.Source`
+if it implements `IDisposable`. Neglecting to do so can lead to memory bloat
+when swapping many bitmaps.
+
 ## License
 
 PanAndZoom is licensed under the [MIT license](LICENSE.TXT).

--- a/samples/AvaloniaDemo.Base/MainView.axaml
+++ b/samples/AvaloniaDemo.Base/MainView.axaml
@@ -173,6 +173,18 @@
             </ScrollViewer>
           </Panel>
         </TabItem>
+        <TabItem Tag="3" Header="Bitmap Swap">
+          <DockPanel Margin="12">
+            <Button Content="Swap Image" DockPanel.Dock="Top"
+                    Click="SwapImage_Click" Width="120" />
+            <paz:ZoomBorder Name="ZoomBorder3" Stretch="Uniform" ZoomSpeed="1.5"
+                            EnableConstrains="False" Background="SlateBlue"
+                            ClipToBounds="True" Focusable="True"
+                            VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+              <Image Name="SwapImage" />
+            </paz:ZoomBorder>
+          </DockPanel>
+        </TabItem>
       </TabControl>
     </Panel>
   </DockPanel>

--- a/samples/AvaloniaDemo.Base/MainView.axaml.cs
+++ b/samples/AvaloniaDemo.Base/MainView.axaml.cs
@@ -1,30 +1,47 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.PanAndZoom;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia.Interactivity;
 
 namespace AvaloniaDemo;
 
 public partial class MainView : UserControl
 {
+    private const string RedImageBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAEklEQVR4nGP8z4APMOGVHbHSAEEsAROxCnMTAAAAAElFTkSuQmCC";
+    private const string BlueImageBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAFElEQVR4nGNkYPjPgBsw4ZEbwdIAPy4BE1xg8ZcAAAAASUVORK5CYII=";
+
+    private bool _toggle;
     public MainView()
     {
         InitializeComponent();
 
-        ZoomBorder1 = this.Find<ZoomBorder>("ZoomBorder1");
         if (ZoomBorder1 != null)
         {
             ZoomBorder1.KeyDown += ZoomBorder_KeyDown;
             ZoomBorder1.ZoomChanged += ZoomBorder_ZoomChanged;
         }
 
-        ZoomBorder2 = this.Find<ZoomBorder>("ZoomBorder2");
         if (ZoomBorder2 != null)
         {
             ZoomBorder2.KeyDown += ZoomBorder_KeyDown;
             ZoomBorder2.ZoomChanged += ZoomBorder_ZoomChanged;
+        }
+
+        if (ZoomBorder3 != null)
+        {
+            ZoomBorder3.KeyDown += ZoomBorder_KeyDown;
+            ZoomBorder3.ZoomChanged += ZoomBorder_ZoomChanged;
+        }
+
+        if (SwapImage != null)
+        {
+            SwapImage.Source = LoadBitmap(RedImageBase64);
         }
 
         DataContext = ZoomBorder1;
@@ -73,9 +90,33 @@ public partial class MainView : UserControl
                     {
                         DataContext = ZoomBorder2;
                     }
+                    else if (tag == "3")
+                    {
+                        DataContext = ZoomBorder3;
+                    }
                 }
             }
         }
+    }
+
+    private void SwapImage_Click(object? sender, RoutedEventArgs e)
+    {
+        if (SwapImage == null)
+            return;
+
+        if (SwapImage.Source is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        SwapImage.Source = LoadBitmap(_toggle ? BlueImageBase64 : RedImageBase64);
+        _toggle = !_toggle;
+    }
+
+    private static Bitmap LoadBitmap(string base64)
+    {
+        var bytes = Convert.FromBase64String(base64);
+        return new Bitmap(new MemoryStream(bytes));
     }
 }
 

--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -179,8 +179,13 @@ public partial class ZoomBorder : Border
     {
         Log($"[ChildChanged] {element}");
 
-        if (element != null && element != _element && _element != null)
+        if (element != _element && _element != null)
         {
+            if (_element is Image oldImage && oldImage.Source is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
             DetachElement();
         }
 


### PR DESCRIPTION
## Summary
- cleanup image when replacing `ZoomBorder` child images
- document bitmap disposal requirement
- add bitmap swapping sample demonstrating disposal logic

## Testing
- `dotnet build PanAndZoom.sln -nologo`

------
https://chatgpt.com/codex/tasks/task_e_687cabe472cc832185b07f18a1cca44f