### PR TITLE
Fix zoom origin handling

### DIFF
--- a/src/PanAndZoom/ZoomBorder.cs
+++ b/src/PanAndZoom/ZoomBorder.cs
@@ -481,7 +481,9 @@ public partial class ZoomBorder : Border
         _updating = true;
 
         Log("[ZoomTo]");
-        _matrix = MatrixHelper.ScaleAtPrepend(_matrix, ratio, ratio, x, y);
+        var inverse = _matrix.Invert();
+        var origin = MatrixHelper.TransformPoint(inverse, new Point(x, y));
+        _matrix = MatrixHelper.ScaleAtPrepend(_matrix, ratio, ratio, origin.X, origin.Y);
         Invalidate(skipTransitions);
 
         _updating = false;

--- a/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTests.cs
+++ b/tests/Avalonia.Controls.PanAndZoom.UnitTests/ZoomBorderTests.cs
@@ -283,4 +283,34 @@ public class ZoomBorderTests
         Assert.Equal(new Size(300, 300), viewport);
         Assert.Equal(new Vector(0, 0), offset);
     }
+
+    [Fact]
+    public void ZoomDeltaTo_LargeMatrix_DoesNotResetOffset()
+    {
+        var target = new ZoomBorder();
+        var initial = MatrixHelper.ScaleAndTranslate(0.25, 0.25, -50, -25);
+        target.SetMatrix(initial);
+
+        const double x = 0;
+        const double y = 0;
+        var expectedScale = 0.25;
+        var expectedOffsetX = -50.0;
+        var expectedOffsetY = -25.0;
+
+        for (var i = 0; i < 10; i++)
+        {
+            target.ZoomDeltaTo(1, x, y);
+            var ratio = target.ZoomSpeed;
+            var localX = (x - expectedOffsetX) / expectedScale;
+            var localY = (y - expectedOffsetY) / expectedScale;
+            expectedOffsetX += expectedScale * localX * (1 - ratio);
+            expectedOffsetY += expectedScale * localY * (1 - ratio);
+            expectedScale *= ratio;
+        }
+
+        Assert.Equal(expectedScale, target.Matrix.M11, 6);
+        Assert.Equal(expectedScale, target.Matrix.M22, 6);
+        Assert.Equal(expectedOffsetX, target.Matrix.M31, 6);
+        Assert.Equal(expectedOffsetY, target.Matrix.M32, 6);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure zoom origin is transformed relative to the current matrix before scaling
- add regression test for repeated ZoomDeltaTo on a large matrix

## Testing
- `dotnet test PanAndZoom.sln -nologo`

------
https://chatgpt.com/codex/tasks/task_e_687cabe6b4ac8321b963dffbfe4fc964